### PR TITLE
MEM-81-AI생성된-커버-사진-실제-사진으로-활용할-수-있도록-수정

### DIFF
--- a/src/features/diary/components/CreateCoverImageDrawer.tsx
+++ b/src/features/diary/components/CreateCoverImageDrawer.tsx
@@ -9,12 +9,14 @@ interface CreateCoverImageDrawerProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   children: React.ReactNode;
+  onImageCreate?: (imageBase64: string) => void;
 }
 
 export const CreateCoverImageDrawer = ({
   open,
   onOpenChange,
   children,
+  onImageCreate,
 }: CreateCoverImageDrawerProps) => {
   const [currentPanel, setCurrentPanel] = useState<"keyword" | "preview">(
     "keyword"
@@ -35,6 +37,9 @@ export const CreateCoverImageDrawer = ({
     mutationFn: (description: string) => api.ai.generateCoverImage(description),
     onSuccess: (data) => {
       setCurrentImageBase64(data);
+      if (onImageCreate) {
+        onImageCreate(data);
+      }
     },
     onError: () => {
       setIsError(true);

--- a/src/features/diary/pages/CreateDiaryBookPage.tsx
+++ b/src/features/diary/pages/CreateDiaryBookPage.tsx
@@ -73,6 +73,23 @@ const CreateDiaryPage = () => {
     useState(false);
   const [isCoverCarouselEnabled, setIsCoverCarouselEnabled] = useState(false);
 
+  // Base64 문자열을 File 객체로 변환하는 함수
+  const base64ToFile = (base64: string, filename: string): File => {
+    const arr = base64.split(",");
+    const mimeMatch = arr[0].match(/:(.*?);/);
+    if (!mimeMatch) {
+      throw new Error("Invalid base64 string");
+    }
+    const mime = mimeMatch[1];
+    const bstr = atob(arr[1]);
+    let n = bstr.length;
+    const u8arr = new Uint8Array(n);
+    while (n--) {
+      u8arr[n] = bstr.charCodeAt(n);
+    }
+    return new File([u8arr], filename, { type: mime });
+  };
+
   useEffect(() => {
     setCanSubmit(diaryTitle.length > 0);
     setIsSpineColorPickerEnabled(diaryTitle.length > 0);
@@ -112,29 +129,22 @@ const CreateDiaryPage = () => {
 
   const handleUploadButtonClick = () => fileInputRef.current?.click();
 
-  /* Server Side */
-  const {
-    mutate: tryCreateDiaryBookWithoutStickers,
-    error: errorWithoutStickers,
-  } = useMutation({
-    mutationFn: async () => {
-      if (!selectedCover) throw new Error("커버 이미지를 선택해주세요");
-      if (!selectedSpineColor) throw new Error("책등 색상을 선택해주세요.");
+  const handleAIImageCreate = (imageBase64: string) => {
+    const filename = `ai-cover-${Date.now()}.png`; // 파일명 생성
+    try {
+      const imageFile = base64ToFile(imageBase64, filename);
+      const newCoverItem: DiaryCoverItem = {
+        type: "file",
+        image: imageFile,
+      };
 
-      // 선택된 커버로부터 이미지파일 추출
-      const coverImageFile = await getCoverImageFile(selectedCover);
-      return api.diaryBook.createDiaryBook({
-        title: diaryTitle,
-        coverImage: coverImageFile,
-        spineColor: selectedSpineColor,
-      });
-    },
-    onSuccess: () => navigate("/main"),
-    onError: (err) =>
-      alert(
-        `일기장 생성 실패: ${err instanceof Error ? err.message : "서버 오류"}`
-      ),
-  });
+      setDiaryCoverItems((prevItems) => [...prevItems, newCoverItem]);
+      setCreateCoverDrawerOpen(false); // 드로어를 닫습니다.
+    } catch (error) {
+      console.error("AI 이미지 변환 중 오류 발생:", error);
+      alert("AI 이미지 처리에 실패했습니다. 다시 시도해주세요.");
+    }
+  };
 
   // 스티커와 함께 다이어리북 생성하는 뮤테이션
   const { mutate: tryCreateDiaryBookWithStickers, error: errorWithStickers } =
@@ -249,6 +259,7 @@ const CreateDiaryPage = () => {
             <CreateCoverImageDrawer
               open={createCoverDrawerOpen}
               onOpenChange={setCreateCoverDrawerOpen}
+              onImageCreate={handleAIImageCreate} // AI 이미지 생성 콜백 전달
             >
               <div
                 className={
@@ -299,14 +310,6 @@ const CreateDiaryPage = () => {
           </Button>
         </div>
 
-        {errorWithoutStickers && (
-          <p className={"text-red-500 text-sm mt-4 text-center"}>
-            오류:{" "}
-            {errorWithoutStickers instanceof Error
-              ? errorWithoutStickers.message
-              : "알 수 없는 오류"}
-          </p>
-        )}
         {errorWithStickers && (
           <p className={"text-red-500 text-sm mt-4 text-center"}>
             스티커 포함 일기장 생성 오류:{" "}


### PR DESCRIPTION
- CreateCoverImageDrawer 컴포넌트에 onImageCreate 콜백 추가하여 AI 이미지 생성 후 처리 가능
- CreateDiaryPage에서 base64 문자열을 File 객체로 변환하는 base64ToFile 함수 구현
- AI 이미지 생성 후 다이어리 커버 아이템에 추가하는 로직 추가
- 불필요한 코드 및 오류 메시지 제거로 UI 개선